### PR TITLE
Swap layer order in example

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,1 +1,3 @@
 keras-resnet was written by Allen Goodman. It’s maintained by Allen Goodman and various contributors:
+
+Claire McQuin <mcquincl@gmail.com> @mcquin

--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,10 @@ A tantalizing preview of keras-resnet simplicity:
 
     >>> y = keras_resnet.ResNet50(x)
     
-    >>> y = keras.layers.Dense(classes)(y)
-    
     >>> y = keras.layers.Flatten()(y.output)
     
+    >>> y = keras.layers.Dense(classes, activation="softmax")(y)
+        
     >>> model = keras.models.Model(x, y)
 
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])


### PR DESCRIPTION
The dense layer should follow the flatten layer. Additionally, use `"softmax"` activation in dense layer.

Resolves #17