### PR TITLE
Fix a bug in temporal shortcut

### DIFF
--- a/keras_resnet/block/temporal.py
+++ b/keras_resnet/block/temporal.py
@@ -98,8 +98,8 @@ def bottleneck(filters, strides=(1, 1), first=False):
 
 
 def _shortcut(a, b):
-    a_shape = keras.backend.int_shape(a)
-    b_shape = keras.backend.int_shape(b)
+    a_shape = keras.backend.int_shape(a)[1:]
+    b_shape = keras.backend.int_shape(b)[1:]
 
     if keras.backend.image_data_format() == "channels_last":
         x = int(round(a_shape[1] // b_shape[1]))


### PR DESCRIPTION
Temporal tensors are 5D, including a temporal axis at axis=1