### PR TITLE
Expose stage features

### DIFF
--- a/keras_resnet/models/_2d.py
+++ b/keras_resnet/models/_2d.py
@@ -64,11 +64,13 @@ def ResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwarg
 
     features = 64
 
+    outputs = []
     for stage_id, iterations in enumerate(blocks):
         for block_id in range(iterations):
             x = block(features, stage_id, block_id, numerical_name=(blocks[stage_id] > 6))(x)
 
         features *= 2
+        outputs.append(x)
 
     if include_top:
         assert classes > 0
@@ -76,7 +78,10 @@ def ResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwarg
         x = keras.layers.GlobalAveragePooling2D(name="pool5")(x)
         x = keras.layers.Dense(classes, activation="softmax", name="fc1000")(x)
 
-    return keras.models.Model(inputs=inputs, outputs=x, *args, **kwargs)
+        return keras.models.Model(inputs=inputs, outputs=x, *args, **kwargs)
+    else:
+        # Else output each stages features
+        return keras.models.Model(inputs=inputs, outputs=outputs, *args, **kwargs)
 
 
 """

--- a/keras_resnet/models/_2d.py
+++ b/keras_resnet/models/_2d.py
@@ -49,7 +49,7 @@ class ResNet(keras.models.Model):
 
     """
 
-    def __init__(self, inputs, blocks, block, include_top=True, classes=1000):
+    def __init__(self, inputs, blocks, block, include_top=True, classes=1000, *args, **kwargs):
         if keras.backend.image_data_format() == "channels_last":
             axis = 3
         else:
@@ -74,7 +74,7 @@ class ResNet(keras.models.Model):
             x = keras.layers.GlobalAveragePooling2D(name="pool5")(x)
             x = keras.layers.Dense(classes, activation="softmax", name="fc1000")(x)
 
-        super(ResNet, self).__init__(inputs, x)
+        super(ResNet, self).__init__(inputs, x, *args, **kwargs)
 
 
 class ResNet18(ResNet):
@@ -104,13 +104,13 @@ class ResNet18(ResNet):
 
     """
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
         if blocks is None:
             blocks = [2, 2, 2, 2]
 
         block = keras_resnet.blocks.basic_2d
 
-        super(ResNet18, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes)
+        super(ResNet18, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 class ResNet34(ResNet):
@@ -140,13 +140,13 @@ class ResNet34(ResNet):
 
     """
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
         block = keras_resnet.blocks.basic_2d
 
-        super(ResNet34, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes)
+        super(ResNet34, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 class ResNet50(ResNet):
@@ -176,13 +176,13 @@ class ResNet50(ResNet):
 
     """
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 6, 3]
 
         block = keras_resnet.blocks.bottleneck_2d
 
-        super(ResNet50, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes)
+        super(ResNet50, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 class ResNet101(ResNet):
@@ -212,13 +212,13 @@ class ResNet101(ResNet):
 
     """
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
         if blocks is None:
             blocks = [3, 4, 23, 3]
 
         block = keras_resnet.blocks.bottleneck_2d
 
-        super(ResNet101, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes)
+        super(ResNet101, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 class ResNet152(ResNet):
@@ -248,13 +248,13 @@ class ResNet152(ResNet):
 
     """
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
         if blocks is None:
             blocks = [3, 8, 36, 3]
 
         block = keras_resnet.blocks.bottleneck_2d
 
-        super(ResNet152, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes)
+        super(ResNet152, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 class ResNet200(ResNet):
@@ -284,10 +284,10 @@ class ResNet200(ResNet):
 
     """
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000):
+    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
         if blocks is None:
             blocks = [3, 24, 36, 3]
 
         block = keras_resnet.blocks.bottleneck_2d
 
-        super(ResNet200, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes)
+        super(ResNet200, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)

--- a/keras_resnet/models/_2d.py
+++ b/keras_resnet/models/_2d.py
@@ -17,277 +17,265 @@ import keras.regularizers
 import keras_resnet.blocks
 
 
-class ResNet(keras.models.Model):
-    """
+"""
 
-    A custom :class:`ResNet <ResNet>` object.
+Constructs a `keras.models.Model` object using the given block count.
 
-    :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
+:param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-    :param blocks: list of blocks to use
+:param blocks: list of blocks to use
 
-    :param include_top: if true, includes classification layers
+:param include_top: if true, includes classification layers
 
-    :param classes: number of classes to classify (include_top must be true)
+:param classes: number of classes to classify (include_top must be true)
 
-    Usage:
+:return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
-        >>> import keras_resnet.blocks
-        >>> import keras_resnet.models
+Usage:
 
-        >>> shape, classes = (224, 224, 3), 1000
+    >>> import keras_resnet.blocks
+    >>> import keras_resnet.models
 
-        >>> x = keras.layers.Input(shape)
+    >>> shape, classes = (224, 224, 3), 1000
 
-        >>> blocks = [2, 2, 2, 2]
+    >>> x = keras.layers.Input(shape)
 
-        >>> block = keras_resnet.blocks.basic_2d
+    >>> blocks = [2, 2, 2, 2]
 
-        >>> model = keras_resnet.models.ResNet(x, classes, blocks, block, classes=classes)
+    >>> block = keras_resnet.blocks.basic_2d
 
-        >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
+    >>> model = keras_resnet.models.ResNet(x, classes, blocks, block, classes=classes)
 
-    """
+    >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-    def __init__(self, inputs, blocks, block, include_top=True, classes=1000, *args, **kwargs):
-        if keras.backend.image_data_format() == "channels_last":
-            axis = 3
-        else:
-            axis = 1
+"""
+def ResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwargs):
+    if keras.backend.image_data_format() == "channels_last":
+        axis = 3
+    else:
+        axis = 1
 
-        x = keras.layers.Conv2D(64, (7, 7), strides=(2, 2), padding="same", name="conv1")(inputs)
-        x = keras.layers.BatchNormalization(axis=axis, name="bn_conv1")(x)
-        x = keras.layers.Activation("relu", name="conv1_relu")(x)
-        x = keras.layers.MaxPooling2D((3, 3), strides=(2, 2), padding="same", name="pool1")(x)
+    x = keras.layers.Conv2D(64, (7, 7), strides=(2, 2), padding="same", name="conv1")(inputs)
+    x = keras.layers.BatchNormalization(axis=axis, name="bn_conv1")(x)
+    x = keras.layers.Activation("relu", name="conv1_relu")(x)
+    x = keras.layers.MaxPooling2D((3, 3), strides=(2, 2), padding="same", name="pool1")(x)
 
-        features = 64
+    features = 64
 
-        for stage_id, iterations in enumerate(blocks):
-            for block_id in range(iterations):
-                x = block(features, stage_id, block_id, numerical_name=(blocks[stage_id] > 6))(x)
+    for stage_id, iterations in enumerate(blocks):
+        for block_id in range(iterations):
+            x = block(features, stage_id, block_id, numerical_name=(blocks[stage_id] > 6))(x)
 
-            features *= 2
+        features *= 2
 
-        if include_top:
-            assert classes > 0
+    if include_top:
+        assert classes > 0
 
-            x = keras.layers.GlobalAveragePooling2D(name="pool5")(x)
-            x = keras.layers.Dense(classes, activation="softmax", name="fc1000")(x)
+        x = keras.layers.GlobalAveragePooling2D(name="pool5")(x)
+        x = keras.layers.Dense(classes, activation="softmax", name="fc1000")(x)
 
-        super(ResNet, self).__init__(inputs, x, *args, **kwargs)
+    return keras.models.Model(inputs=inputs, outputs=x, *args, **kwargs)
 
 
-class ResNet18(ResNet):
-    """
+"""
 
-    A :class:`ResNet18 <ResNet18>` object.
+Constructs a `keras.models.Model` according to the ResNet18 specifications.
 
-    :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
+:param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-    :param blocks: list of blocks to use
+:param blocks: list of blocks to use
 
-    :param include_top: if true, includes classification layers
+:param include_top: if true, includes classification layers
 
-    :param classes: number of classes to classify (include_top must be true)
+:param classes: number of classes to classify (include_top must be true)
 
-    Usage:
+:return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
-        >>> import keras_resnet.models
+Usage:
 
-        >>> shape, classes = (224, 224, 3), 1000
+    >>> import keras_resnet.models
 
-        >>> x = keras.layers.Input(shape)
+    >>> shape, classes = (224, 224, 3), 1000
 
-        >>> model = keras_resnet.models.ResNet18(x, classes=classes)
+    >>> x = keras.layers.Input(shape)
 
-        >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
+    >>> model = keras_resnet.models.ResNet18(x, classes=classes)
 
-    """
+    >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
-        if blocks is None:
-            blocks = [2, 2, 2, 2]
+"""
+def ResNet18(inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
+    if blocks is None:
+        blocks = [2, 2, 2, 2]
 
-        block = keras_resnet.blocks.basic_2d
+    return ResNet(inputs, blocks, block=keras_resnet.blocks.basic_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
-        super(ResNet18, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
 
+"""
 
-class ResNet34(ResNet):
-    """
+Constructs a `keras.models.Model` according to the ResNet34 specifications.
 
-    A :class:`ResNet34 <ResNet34>` object.
+:param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-    :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
+:param blocks: list of blocks to use
 
-    :param blocks: list of blocks to use
+:param include_top: if true, includes classification layers
 
-    :param include_top: if true, includes classification layers
+:param classes: number of classes to classify (include_top must be true)
 
-    :param classes: number of classes to classify (include_top must be true)
+:return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
-    Usage:
+Usage:
 
-        >>> import keras_resnet.models
+    >>> import keras_resnet.models
 
-        >>> shape, classes = (224, 224, 3), 1000
+    >>> shape, classes = (224, 224, 3), 1000
 
-        >>> x = keras.layers.Input(shape)
+    >>> x = keras.layers.Input(shape)
 
-        >>> model = keras_resnet.models.ResNet34(x, classes=classes)
+    >>> model = keras_resnet.models.ResNet34(x, classes=classes)
 
-        >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
+    >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-    """
+"""
+def ResNet34(inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
+    if blocks is None:
+        blocks = [3, 4, 6, 3]
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
-        if blocks is None:
-            blocks = [3, 4, 6, 3]
+    return ResNet(inputs, blocks, block=keras_resnet.blocks.basic_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
-        block = keras_resnet.blocks.basic_2d
 
-        super(ResNet34, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
+"""
 
+Constructs a `keras.models.Model` according to the ResNet50 specifications.
 
-class ResNet50(ResNet):
-    """
+:param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-    A :class:`ResNet50 <ResNet50>` object.
+:param blocks: list of blocks to use
 
-    :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
+:param include_top: if true, includes classification layers
 
-    :param blocks: list of blocks to use
+:param classes: number of classes to classify (include_top must be true)
 
-    :param include_top: if true, includes classification layers
+:return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
-    :param classes: number of classes to classify (include_top must be true)
+Usage:
 
-    Usage:
+    >>> import keras_resnet.models
 
-        >>> import keras_resnet.models
+    >>> shape, classes = (224, 224, 3), 1000
 
-        >>> shape, classes = (224, 224, 3), 1000
+    >>> x = keras.layers.Input(shape)
 
-        >>> x = keras.layers.Input(shape)
+    >>> model = keras_resnet.models.ResNet50(x)
 
-        >>> model = keras_resnet.models.ResNet50(x)
+    >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-        >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
+"""
+def ResNet50(inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
+    if blocks is None:
+        blocks = [3, 4, 6, 3]
 
-    """
+    return ResNet(inputs, blocks, block=keras_resnet.blocks.bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
-        if blocks is None:
-            blocks = [3, 4, 6, 3]
 
-        block = keras_resnet.blocks.bottleneck_2d
+"""
 
-        super(ResNet50, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
+Constructs a `keras.models.Model` according to the ResNet101 specifications.
 
+:param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-class ResNet101(ResNet):
-    """
+:param blocks: list of blocks to use
 
-    A :class:`ResNet101 <ResNet101>` object.
+:param include_top: if true, includes classification layers
 
-    :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
+:param classes: number of classes to classify (include_top must be true)
 
-    :param blocks: list of blocks to use
+:return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
-    :param include_top: if true, includes classification layers
+Usage:
 
-    :param classes: number of classes to classify (include_top must be true)
+    >>> import keras_resnet.models
 
-    Usage:
+    >>> shape, classes = (224, 224, 3), 1000
 
-        >>> import keras_resnet.models
+    >>> x = keras.layers.Input(shape)
 
-        >>> shape, classes = (224, 224, 3), 1000
+    >>> model = keras_resnet.models.ResNet101(x, classes=classes)
 
-        >>> x = keras.layers.Input(shape)
+    >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-        >>> model = keras_resnet.models.ResNet101(x, classes=classes)
+"""
+def ResNet101(inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
+    if blocks is None:
+        blocks = [3, 4, 23, 3]
 
-        >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
+    return ResNet(inputs, blocks, block=keras_resnet.blocks.bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
-    """
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
-        if blocks is None:
-            blocks = [3, 4, 23, 3]
+"""
 
-        block = keras_resnet.blocks.bottleneck_2d
+Constructs a `keras.models.Model` according to the ResNet152 specifications.
 
-        super(ResNet101, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
+:param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
+:param blocks: list of blocks to use
 
-class ResNet152(ResNet):
-    """
+:param include_top: if true, includes classification layers
 
-    A :class:`ResNet152 <ResNet152>` object.
+:param classes: number of classes to classify (include_top must be true)
 
-    :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
+:return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
-    :param blocks: list of blocks to use
+Usage:
 
-    :param include_top: if true, includes classification layers
+    >>> import keras_resnet.models
 
-    :param classes: number of classes to classify (include_top must be true)
+    >>> shape, classes = (224, 224, 3), 1000
 
-    Usage:
+    >>> x = keras.layers.Input(shape)
 
-        >>> import keras_resnet.models
+    >>> model = keras_resnet.models.ResNet152(x, classes=classes)
 
-        >>> shape, classes = (224, 224, 3), 1000
+    >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-        >>> x = keras.layers.Input(shape)
+"""
+def ResNet152(inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
+    if blocks is None:
+        blocks = [3, 8, 36, 3]
 
-        >>> model = keras_resnet.models.ResNet152(x, classes=classes)
+    return ResNet(inputs, blocks, block=keras_resnet.blocks.bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
-        >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-    """
+"""
 
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
-        if blocks is None:
-            blocks = [3, 8, 36, 3]
+Constructs a `keras.models.Model` according to the ResNet200 specifications.
 
-        block = keras_resnet.blocks.bottleneck_2d
+:param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-        super(ResNet152, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
+:param blocks: list of blocks to use
 
+:param include_top: if true, includes classification layers
 
-class ResNet200(ResNet):
-    """
+:param classes: number of classes to classify (include_top must be true)
 
-    A :class:`ResNet200 <ResNet200>` object.
+:return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
-    :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
+Usage:
 
-    :param blocks: list of blocks to use
+    >>> import keras_resnet.models
 
-    :param include_top: if true, includes classification layers
+    >>> shape, classes = (224, 224, 3), 1000
 
-    :param classes: number of classes to classify (include_top must be true)
+    >>> x = keras.layers.Input(shape)
 
-    Usage:
+    >>> model = keras_resnet.models.ResNet200(x, classes=classes)
 
-        >>> import keras_resnet.models
+    >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
-        >>> shape, classes = (224, 224, 3), 1000
+"""
+def ResNet200(inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
+    if blocks is None:
+        blocks = [3, 24, 36, 3]
 
-        >>> x = keras.layers.Input(shape)
-
-        >>> model = keras_resnet.models.ResNet200(x, classes=classes)
-
-        >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-
-    """
-
-    def __init__(self, inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
-        if blocks is None:
-            blocks = [3, 24, 36, 3]
-
-        block = keras_resnet.blocks.bottleneck_2d
-
-        super(ResNet200, self).__init__(inputs, blocks, block, include_top=include_top, classes=classes, *args, **kwargs)
+    return ResNet(inputs, blocks, block=keras_resnet.blocks.bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)

--- a/keras_resnet/models/_2d.py
+++ b/keras_resnet/models/_2d.py
@@ -104,7 +104,6 @@ Usage:
     >>> model = keras_resnet.models.ResNet18(x, classes=classes)
 
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-
 """
 def ResNet18(inputs, blocks=None, include_top=True, classes=1000, *args, **kwargs):
     if blocks is None:

--- a/keras_resnet/models/_2d.py
+++ b/keras_resnet/models/_2d.py
@@ -23,7 +23,9 @@ Constructs a `keras.models.Model` object using the given block count.
 
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-:param blocks: list of blocks to use
+:param blocks: the network’s residual architecture
+
+:param block: a residual block (e.g. an instance of `keras_resnet.blocks.basic_2d`)
 
 :param include_top: if true, includes classification layers
 
@@ -83,7 +85,7 @@ Constructs a `keras.models.Model` according to the ResNet18 specifications.
 
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-:param blocks: list of blocks to use
+:param blocks: the network’s residual architecture
 
 :param include_top: if true, includes classification layers
 
@@ -117,7 +119,7 @@ Constructs a `keras.models.Model` according to the ResNet34 specifications.
 
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-:param blocks: list of blocks to use
+:param blocks: the network’s residual architecture
 
 :param include_top: if true, includes classification layers
 
@@ -151,7 +153,7 @@ Constructs a `keras.models.Model` according to the ResNet50 specifications.
 
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-:param blocks: list of blocks to use
+:param blocks: the network’s residual architecture
 
 :param include_top: if true, includes classification layers
 
@@ -185,7 +187,7 @@ Constructs a `keras.models.Model` according to the ResNet101 specifications.
 
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-:param blocks: list of blocks to use
+:param blocks: the network’s residual architecture
 
 :param include_top: if true, includes classification layers
 
@@ -219,7 +221,7 @@ Constructs a `keras.models.Model` according to the ResNet152 specifications.
 
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-:param blocks: list of blocks to use
+:param blocks: the network’s residual architecture
 
 :param include_top: if true, includes classification layers
 
@@ -253,7 +255,7 @@ Constructs a `keras.models.Model` according to the ResNet200 specifications.
 
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
-:param blocks: list of blocks to use
+:param blocks: the network’s residual architecture
 
 :param include_top: if true, includes classification layers
 

--- a/keras_resnet/models/_time_distributed_2d.py
+++ b/keras_resnet/models/_time_distributed_2d.py
@@ -52,8 +52,6 @@ Usage:
 
     >>> y = keras.layers.TimeDistributed(keras.layers.Dense(classes, activation="softmax"))(y)
 
-    >>> model = keras.models.Model(x, y)
-
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
@@ -170,8 +168,6 @@ Constructs a time distributed `keras.models.Model` according to the ResNet50 spe
 :param include_top: if true, includes classification layers
 
 :param classes: number of classes to classify (include_top must be true)
-
-:return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
 Usage:
 

--- a/keras_resnet/models/_time_distributed_2d.py
+++ b/keras_resnet/models/_time_distributed_2d.py
@@ -68,11 +68,13 @@ def TimeDistributedResNet(inputs, blocks, block, include_top=True, classes=1000,
 
     features = 64
 
+    outputs = []
     for stage_id, iterations in enumerate(blocks):
         for block_id in range(iterations):
             x = block(features, stage_id, block_id, numerical_name=(blocks[stage_id] > 6))(x)
 
         features *= 2
+        outputs.append(x)
 
     if include_top:
         assert classes > 0
@@ -80,7 +82,10 @@ def TimeDistributedResNet(inputs, blocks, block, include_top=True, classes=1000,
         x = keras.layers.TimeDistributed(keras.layers.GlobalAveragePooling2D(), name="pool5")(x)
         x = keras.layers.TimeDistributed(keras.layers.Dense(classes, activation="softmax"), name="fc1000")(x)
 
-    return keras.models.Model(inputs=inputs, outputs=x, *args, **kwargs)
+        return keras.models.Model(inputs=inputs, outputs=x, *args, **kwargs)
+    else:
+        # Else output each stages features
+        return keras.models.Model(inputs=inputs, outputs=outputs, *args, **kwargs)
 
 
 """

--- a/keras_resnet/models/_time_distributed_2d.py
+++ b/keras_resnet/models/_time_distributed_2d.py
@@ -27,6 +27,10 @@ Constructs a time distributed `keras.models.Model` object using the given block 
 
 :param block: a time distributed residual block (e.g. an instance of `keras_resnet.blocks.time_distributed_basic_2d`)
 
+:param include_top: if true, includes classification layers
+
+:param classes: number of classes to classify (include_top must be true)
+
 :return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
 Usage:
@@ -53,41 +57,30 @@ Usage:
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
-def TimeDistributedResNet(inputs, blocks, block, *args, **kwargs):
+def TimeDistributedResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwargs):
     if keras.backend.image_data_format() == "channels_last":
         axis = 3
     else:
         axis = 1
 
-    x = keras.layers.TimeDistributed(keras.layers.Conv2D(64, (7, 7), strides=(2, 2), padding="same"))(inputs)
-    x = keras.layers.TimeDistributed(keras.layers.BatchNormalization(axis=axis))(x)
-    x = keras.layers.TimeDistributed(keras.layers.Activation("relu"))(x)
-    x = keras.layers.TimeDistributed(keras.layers.MaxPooling2D((3, 3), strides=(2, 2), padding="same"))(x)
+    x = keras.layers.TimeDistributed(keras.layers.Conv2D(64, (7, 7), strides=(2, 2), padding="same"), name="conv1")(inputs)
+    x = keras.layers.TimeDistributed(keras.layers.BatchNormalization(axis=axis), name="bn_conv1")(x)
+    x = keras.layers.TimeDistributed(keras.layers.Activation("relu"), name="conv1_relu")(x)
+    x = keras.layers.TimeDistributed(keras.layers.MaxPooling2D((3, 3), strides=(2, 2), padding="same"), name="pool1")(x)
 
     features = 64
 
-    for j, iterations in enumerate(blocks):
-        for k in range(iterations):
-            if k == 0 and not j == 0:
-                strides = (2, 2)
-            else:
-                strides = (1, 1)
-
-            x = block(features, strides, j == 0 and k == 0)(x)
+    for stage_id, iterations in enumerate(blocks):
+        for block_id in range(iterations):
+            x = block(features, stage_id, block_id, numerical_name=(blocks[stage_id] > 6))(x)
 
         features *= 2
 
-    x = keras.layers.TimeDistributed(keras.layers.BatchNormalization(axis=axis))(x)
-    x = keras.layers.TimeDistributed(keras.layers.Activation("relu"))(x)
+    if include_top:
+        assert classes > 0
 
-    shape = keras.backend.int_shape(x)
-
-    if keras.backend.image_data_format() == "channels_last":
-        pool_size = (shape[1], shape[2])
-    else:
-        pool_size = (shape[2], shape[3])
-
-    x = keras.layers.TimeDistributed(keras.layers.AveragePooling2D(pool_size, strides=(1, 1)))(x)
+        x = keras.layers.TimeDistributed(keras.layers.GlobalAveragePooling2D(), name="pool5")(x)
+        x = keras.layers.TimeDistributed(keras.layers.Dense(classes, activation="softmax"), name="fc1000")(x)
 
     return keras.models.Model(inputs=inputs, outputs=x, *args, **kwargs)
 
@@ -99,6 +92,10 @@ Constructs a time distributed `keras.models.Model` according to the ResNet18 spe
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
 :param blocks: the network’s residual architecture
+
+:param include_top: if true, includes classification layers
+
+:param classes: number of classes to classify (include_top must be true)
 
 :return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -121,8 +118,8 @@ Usage:
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
-def TimeDistributedResNet18(inputs, blocks=[2, 2, 2, 2], *args, **kwargs):
-    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_basic_2d, *args, **kwargs)
+def TimeDistributedResNet18(inputs, blocks=[2, 2, 2, 2], include_top=True, classes=1000, *args, **kwargs):
+    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_basic_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 """
@@ -132,6 +129,10 @@ Constructs a time distributed `keras.models.Model` according to the ResNet34 spe
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
 :param blocks: the network’s residual architecture
+
+:param include_top: if true, includes classification layers
+
+:param classes: number of classes to classify (include_top must be true)
 
 :return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -154,8 +155,8 @@ Usage:
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
-def TimeDistributedResNet34(inputs, blocks=[3, 4, 6, 3], *args, **kwargs):
-    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_basic_2d, *args, **kwargs)
+def TimeDistributedResNet34(inputs, blocks=[3, 4, 6, 3], include_top=True, classes=1000, *args, **kwargs):
+    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_basic_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 """
@@ -165,6 +166,10 @@ Constructs a time distributed `keras.models.Model` according to the ResNet50 spe
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
 :param blocks: the network’s residual architecture
+
+:param include_top: if true, includes classification layers
+
+:param classes: number of classes to classify (include_top must be true)
 
 :return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -187,8 +192,8 @@ Usage:
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
-def TimeDistributedResNet50(inputs, blocks=[3, 4, 6, 3], *args, **kwargs):
-    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, *args, **kwargs)
+def TimeDistributedResNet50(inputs, blocks=[3, 4, 6, 3], include_top=True, classes=1000, *args, **kwargs):
+    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 """
@@ -198,6 +203,10 @@ Constructs a time distributed `keras.models.Model` according to the ResNet101 sp
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
 :param blocks: the network’s residual architecture
+
+:param include_top: if true, includes classification layers
+
+:param classes: number of classes to classify (include_top must be true)
 
 :return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -220,8 +229,8 @@ Usage:
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
-def TimeDistributedResNet101(inputs, blocks=[3, 4, 23, 3], *args, **kwargs):
-    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, *args, **kwargs)
+def TimeDistributedResNet101(inputs, blocks=[3, 4, 23, 3], include_top=True, classes=1000, *args, **kwargs):
+    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 """
@@ -231,6 +240,10 @@ Constructs a time distributed `keras.models.Model` according to the ResNet152 sp
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
 :param blocks: the network’s residual architecture
+
+:param include_top: if true, includes classification layers
+
+:param classes: number of classes to classify (include_top must be true)
 
 :return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -253,8 +266,8 @@ Usage:
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
-def TimeDistributedResNet152(inputs, *args, **kwargs):
-    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, *args, **kwargs)
+def TimeDistributedResNet152(inputs, blocks=[3, 8, 36, 3], include_top=True, classes=1000, *args, **kwargs):
+    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)
 
 
 """
@@ -264,6 +277,10 @@ Constructs a time distributed `keras.models.Model` according to the ResNet200 sp
 :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
 
 :param blocks: the network’s residual architecture
+
+:param include_top: if true, includes classification layers
+
+:param classes: number of classes to classify (include_top must be true)
 
 :return model: Time distributed ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -286,5 +303,5 @@ Usage:
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 
 """
-def TimeDistributedResNet200(inputs, blocks=[3, 24, 36, 3], *args, **kwargs):
-    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, *args, **kwargs)
+def TimeDistributedResNet200(inputs, blocks=[3, 24, 36, 3], include_top=True, classes=1000, *args, **kwargs):
+    return TimeDistributedResNet(inputs, blocks, block=keras_resnet.blocks.time_distributed_bottleneck_2d, include_top=include_top, classes=classes, *args, **kwargs)

--- a/keras_resnet/models/_time_distributed_2d.py
+++ b/keras_resnet/models/_time_distributed_2d.py
@@ -19,11 +19,11 @@ import keras_resnet.blocks
 
 class TimeDistributedResNet(keras.models.Model):
     """
-    
+
     A custom :class:`TimeDistributedResNet <TimeDistributedResNet>` object.
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
-    
+
     :param blocks: the network’s residual architecture
 
     :param block: a time distributed residual block (e.g. an instance of `keras_resnet.blocks.time_distributed_basic_2d`)
@@ -50,10 +50,10 @@ class TimeDistributedResNet(keras.models.Model):
         >>> model = keras.models.Model(x, y)
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-    
+
     """
 
-    def __init__(self, inputs, blocks, block):
+    def __init__(self, inputs, blocks, block, *args, **kwargs):
         if keras.backend.image_data_format() == "channels_last":
             axis = 3
         else:
@@ -89,12 +89,12 @@ class TimeDistributedResNet(keras.models.Model):
 
         x = keras.layers.TimeDistributed(keras.layers.AveragePooling2D(pool_size, strides=(1, 1)))(x)
 
-        super(TimeDistributedResNet, self).__init__(inputs, x)
+        super(TimeDistributedResNet, self).__init__(inputs, x, *args, **kwargs)
 
 
 class TimeDistributedResNet18(TimeDistributedResNet):
     """
-    
+
     A :class:`TimeDistributedResNet18 <TimeDistributedResNet18>` object.
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
@@ -116,20 +116,20 @@ class TimeDistributedResNet18(TimeDistributedResNet):
         >>> model = keras.models.Model(x, y)
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-    
+
     """
 
-    def __init__(self, inputs):
+    def __init__(self, inputs, *args, **kwargs):
         blocks = [2, 2, 2, 2]
 
         block = keras_resnet.blocks.time_distributed_basic_2d
 
-        super(TimeDistributedResNet18, self).__init__(inputs, blocks, block)
+        super(TimeDistributedResNet18, self).__init__(inputs, blocks, block, *args, **kwargs)
 
 
 class TimeDistributedResNet34(TimeDistributedResNet):
     """
-    
+
     A :class:`TimeDistributedResNet34 <TimeDistributedResNet34>` object.
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
@@ -151,20 +151,20 @@ class TimeDistributedResNet34(TimeDistributedResNet):
         >>> model = keras.models.Model(x, y)
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-    
+
     """
 
-    def __init__(self, inputs):
+    def __init__(self, inputs, *args, **kwargs):
         blocks = [3, 4, 6, 3]
 
         block = keras_resnet.blocks.time_distributed_basic_2d
 
-        super(TimeDistributedResNet34, self).__init__(inputs, blocks, block)
+        super(TimeDistributedResNet34, self).__init__(inputs, blocks, block, *args, **kwargs)
 
 
 class TimeDistributedResNet50(TimeDistributedResNet):
     """
-    
+
     A :class:`TimeDistributedResNet50 <TimeDistributedResNet50>` object.
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
@@ -186,20 +186,20 @@ class TimeDistributedResNet50(TimeDistributedResNet):
         >>> model = keras.models.Model(x, y)
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-    
+
     """
 
-    def __init__(self, inputs):
+    def __init__(self, inputs, *args, **kwargs):
         blocks = [3, 4, 6, 3]
 
         block = keras_resnet.blocks.time_distributed_bottleneck_2d
 
-        super(TimeDistributedResNet50, self).__init__(inputs, blocks, block)
+        super(TimeDistributedResNet50, self).__init__(inputs, blocks, block, *args, **kwargs)
 
 
 class TimeDistributedResNet101(TimeDistributedResNet):
     """
-    
+
     A :class:`TimeDistributedResNet101 <TimeDistributedResNet101>` object.
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
@@ -221,20 +221,20 @@ class TimeDistributedResNet101(TimeDistributedResNet):
         >>> model = keras.models.Model(x, y)
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-    
+
     """
 
-    def __init__(self, inputs):
+    def __init__(self, inputs, *args, **kwargs):
         blocks = [3, 4, 23, 3]
 
         block = keras_resnet.blocks.time_distributed_bottleneck_2d
 
-        super(TimeDistributedResNet101, self).__init__(inputs, blocks, block)
+        super(TimeDistributedResNet101, self).__init__(inputs, blocks, block, *args, **kwargs)
 
 
 class TimeDistributedResNet152(TimeDistributedResNet):
     """
-    
+
     A :class:`TimeDistributedResNet152 <TimeDistributedResNet152>` object.
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
@@ -256,20 +256,20 @@ class TimeDistributedResNet152(TimeDistributedResNet):
         >>> model = keras.models.Model(x, y)
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-    
+
     """
 
-    def __init__(self, inputs):
+    def __init__(self, inputs, *args, **kwargs):
         blocks = [3, 8, 36, 3]
 
         block = keras_resnet.blocks.time_distributed_bottleneck_2d
 
-        super(TimeDistributedResNet152, self).__init__(inputs, blocks, block)
+        super(TimeDistributedResNet152, self).__init__(inputs, blocks, block, *args, **kwargs)
 
 
 class TimeDistributedResNet200(TimeDistributedResNet):
     """
-    
+
     A :class:`TimeDistributedResNet200 <TimeDistributedResNet200>` object.
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
@@ -291,12 +291,12 @@ class TimeDistributedResNet200(TimeDistributedResNet):
         >>> model = keras.models.Model(x, y)
 
         >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
-    
+
     """
 
-    def __init__(self, inputs):
+    def __init__(self, inputs, *args, **kwargs):
         blocks = [3, 24, 36, 3]
 
         block = keras_resnet.blocks.time_distributed_bottleneck_2d
 
-        super(TimeDistributedResNet200, self).__init__(inputs, blocks, block)
+        super(TimeDistributedResNet200, self).__init__(inputs, blocks, block, *args, **kwargs)


### PR DESCRIPTION
In case `include_top=False`, this PR changes the output to return res2-res5 features. This is useful for architectures such as FPN or FCN, where these features are used.

Note: This PR depends on https://github.com/broadinstitute/keras-resnet/pull/26 , which should be merged before this one.