### PR TITLE
Add missing import keras to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ A tantalizing preview of Keras-ResNet simplicity:
 
 .. code-block:: python
 
+    >>> import keras
+
     >>> import keras_resnet.models
 
     >>> shape, classes = (32, 32, 3), 10


### PR DESCRIPTION
Without that the basic example fails on `NameError: name 'keras' is not defined`.