### PR TITLE
Add option to freeze BatchNorm layers.

### DIFF
--- a/keras_resnet/blocks/_1d.py
+++ b/keras_resnet/blocks/_1d.py
@@ -10,12 +10,14 @@ This module implements a number of popular one-dimensional residual blocks.
 import keras.layers
 import keras.regularizers
 
+import keras_resnet.layers
+
 parameters = {
     "kernel_initializer": "he_normal"
 }
 
 
-def basic_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None):
+def basic_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None, freeze_bn=False):
     """
     A one-dimensional basic block.
 
@@ -30,6 +32,8 @@ def basic_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, str
     :param numerical_name: if true, uses numbers to represent blocks instead of chars (ResNet{101, 152, 200})
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
+
+    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -49,35 +53,35 @@ def basic_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, str
         axis = 1
 
     if block > 0 and numerical_name:
-        block_identifier = "b{}".format(block)
+        block_char = "b{}".format(block)
     else:
-        block_identifier = chr(ord('a') + block)
+        block_char = chr(ord('a') + block)
 
-    stage_identifier = str(stage + 2)
+    stage_char = str(stage + 2)
 
     def f(x):
-        y = keras.layers.Conv1D(filters, kernel_size, strides=stride, padding="same", name="res{}{}_branch2a".format(stage_identifier, block_identifier), **parameters)(x)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2a".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv1D(filters, kernel_size, strides=stride, padding="same", name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv1D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2b".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv1D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         if block == 0:
-            shortcut = keras.layers.Conv1D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch1".format(stage_identifier, block_identifier), **parameters)(x)
-            shortcut = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch1".format(stage_identifier, block_identifier))(shortcut)
+            shortcut = keras.layers.Conv1D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
+            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
-        y = keras.layers.Add(name="res{}{}".format(stage_identifier, block_identifier))([y, shortcut])
-        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Add(name="res{}{}".format(stage_char, block_char))([y, shortcut])
+        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_char, block_char))(y)
 
         return y
 
     return f
 
 
-def bottleneck_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None):
+def bottleneck_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None, freeze_bn=False):
     """
     A one-dimensional bottleneck block.
 
@@ -92,6 +96,8 @@ def bottleneck_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False
     :param numerical_name: if true, uses numbers to represent blocks instead of chars (ResNet{101, 152, 200})
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
+
+    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -108,32 +114,32 @@ def bottleneck_1d(filters, stage=0, block=0, kernel_size=3, numerical_name=False
         axis = 1
 
     if block > 0 and numerical_name:
-        block_identifier = "b{}".format(block)
+        block_char = "b{}".format(block)
     else:
-        block_identifier = chr(ord('a') + block)
+        block_char = chr(ord('a') + block)
 
-    stage_identifier = str(stage + 2)
+    stage_char = str(stage + 2)
 
     def f(x):
-        y = keras.layers.Conv1D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch2a".format(stage_identifier, block_identifier), **parameters)(x)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2a".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv1D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv1D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2b".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv1D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv1D(filters * 4, (1, 1), padding="same", name="res{}{}_branch2c".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2c".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv1D(filters * 4, (1, 1), padding="same", name="res{}{}_branch2c".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2c".format(stage_char, block_char))(y)
 
         if block == 0:
-            shortcut = keras.layers.Conv1D(filters * 4, (1, 1), strides=stride, name="res{}{}_branch1".format(stage_identifier, block_identifier), **parameters)(x)
-            shortcut = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch1".format(stage_identifier, block_identifier))(shortcut)
+            shortcut = keras.layers.Conv1D(filters * 4, (1, 1), strides=stride, name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
+            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
-        y = keras.layers.Add(name="res{}{}".format(stage_identifier, block_identifier))([y, shortcut])
-        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Add(name="res{}{}".format(stage_char, block_char))([y, shortcut])
+        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_char, block_char))(y)
 
         return y
 

--- a/keras_resnet/blocks/_2d.py
+++ b/keras_resnet/blocks/_2d.py
@@ -10,12 +10,14 @@ This module implements a number of popular two-dimensional residual blocks.
 import keras.layers
 import keras.regularizers
 
+import keras_resnet.layers
+
 parameters = {
     "kernel_initializer": "he_normal"
 }
 
 
-def basic_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None):
+def basic_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None, freeze_bn=False):
     """
     A two-dimensional basic block.
 
@@ -30,6 +32,8 @@ def basic_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, str
     :param numerical_name: if true, uses numbers to represent blocks instead of chars (ResNet{101, 152, 200})
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
+
+    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -49,35 +53,35 @@ def basic_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, str
         axis = 1
 
     if block > 0 and numerical_name:
-        block_identifier = "b{}".format(block)
+        block_char = "b{}".format(block)
     else:
-        block_identifier = chr(ord('a') + block)
+        block_char = chr(ord('a') + block)
 
     stage_char = str(stage + 2)
 
     def f(x):
-        y = keras.layers.Conv2D(filters, kernel_size, strides=stride, padding="same", name="res{}{}_branch2a".format(stage_char, block_identifier), **parameters)(x)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2a".format(stage_char, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_identifier))(y)
+        y = keras.layers.Conv2D(filters, kernel_size, strides=stride, padding="same", name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv2D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_char, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2b".format(stage_char, block_identifier))(y)
+        y = keras.layers.Conv2D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         if block == 0:
-            shortcut = keras.layers.Conv2D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch1".format(stage_char, block_identifier), **parameters)(x)
-            shortcut = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch1".format(stage_char, block_identifier))(shortcut)
+            shortcut = keras.layers.Conv2D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
+            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
-        y = keras.layers.Add(name="res{}{}".format(stage_char, block_identifier))([y, shortcut])
-        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_char, block_identifier))(y)
+        y = keras.layers.Add(name="res{}{}".format(stage_char, block_char))([y, shortcut])
+        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_char, block_char))(y)
 
         return y
 
     return f
 
 
-def bottleneck_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None):
+def bottleneck_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None, freeze_bn=False):
     """
     A two-dimensional bottleneck block.
 
@@ -92,6 +96,8 @@ def bottleneck_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False
     :param numerical_name: if true, uses numbers to represent blocks instead of chars (ResNet{101, 152, 200})
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
+
+    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -111,32 +117,32 @@ def bottleneck_2d(filters, stage=0, block=0, kernel_size=3, numerical_name=False
         axis = 1
 
     if block > 0 and numerical_name:
-        block_identifier = "b{}".format(block)
+        block_char = "b{}".format(block)
     else:
-        block_identifier = chr(ord('a') + block)
+        block_char = chr(ord('a') + block)
 
-    stage_identifier = str(stage + 2)
+    stage_char = str(stage + 2)
 
     def f(x):
-        y = keras.layers.Conv2D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch2a".format(stage_identifier, block_identifier), **parameters)(x)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2a".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv2D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv2D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2b".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv2D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv2D(filters * 4, (1, 1), padding="same", name="res{}{}_branch2c".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2c".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv2D(filters * 4, (1, 1), padding="same", name="res{}{}_branch2c".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2c".format(stage_char, block_char))(y)
 
         if block == 0:
-            shortcut = keras.layers.Conv2D(filters * 4, (1, 1), strides=stride, name="res{}{}_branch1".format(stage_identifier, block_identifier), **parameters)(x)
-            shortcut = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch1".format(stage_identifier, block_identifier))(shortcut)
+            shortcut = keras.layers.Conv2D(filters * 4, (1, 1), strides=stride, name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
+            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
-        y = keras.layers.Add(name="res{}{}".format(stage_identifier, block_identifier))([y, shortcut])
-        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Add(name="res{}{}".format(stage_char, block_char))([y, shortcut])
+        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_char, block_char))(y)
 
         return y
 

--- a/keras_resnet/blocks/_3d.py
+++ b/keras_resnet/blocks/_3d.py
@@ -10,12 +10,14 @@ This module implements a number of popular three-dimensional residual blocks.
 import keras.layers
 import keras.regularizers
 
+import keras_resnet.layers
+
 parameters = {
     "kernel_initializer": "he_normal"
 }
 
 
-def basic_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None):
+def basic_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None, freeze_bn=False):
     """
     A three-dimensional basic block.
 
@@ -30,6 +32,8 @@ def basic_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, str
     :param numerical_name: if true, uses numbers to represent blocks instead of chars (ResNet{101, 152, 200})
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
+
+    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -49,35 +53,35 @@ def basic_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, str
         axis = 1
 
     if block > 0 and numerical_name:
-        block_identifier = "b{}".format(block)
+        block_char = "b{}".format(block)
     else:
-        block_identifier = chr(ord('a') + block)
+        block_char = chr(ord('a') + block)
 
-    stage_identifier = str(stage + 2)
+    stage_char = str(stage + 2)
 
     def f(x):
-        y = keras.layers.Conv3D(filters, kernel_size, strides=stride, padding="same", name="res{}{}_branch2a".format(stage_identifier, block_identifier), **parameters)(x)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2a".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv3D(filters, kernel_size, strides=stride, padding="same", name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv3D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2b".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv3D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
 
         if block == 0:
-            shortcut = keras.layers.Conv3D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch1".format(stage_identifier, block_identifier), **parameters)(x)
-            shortcut = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch1".format(stage_identifier, block_identifier))(shortcut)
+            shortcut = keras.layers.Conv3D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
+            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
-        y = keras.layers.Add(name="res{}{}".format(stage_identifier, block_identifier))([y, shortcut])
-        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Add(name="res{}{}".format(stage_char, block_char))([y, shortcut])
+        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_char, block_char))(y)
 
         return y
 
     return f
 
 
-def bottleneck_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None):
+def bottleneck_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False, stride=None, freeze_bn=False):
     """
     A three-dimensional bottleneck block.
 
@@ -92,6 +96,8 @@ def bottleneck_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False
     :param numerical_name: if true, uses numbers to represent blocks instead of chars (ResNet{101, 152, 200})
 
     :param stride: int representing the stride used in the shortcut and the first conv layer, default derives stride from block id
+
+    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     Usage:
 
@@ -111,32 +117,32 @@ def bottleneck_3d(filters, stage=0, block=0, kernel_size=3, numerical_name=False
         axis = 1
 
     if block > 0 and numerical_name:
-        block_identifier = "b{}".format(block)
+        block_char = "b{}".format(block)
     else:
-        block_identifier = chr(ord('a') + block)
+        block_char = chr(ord('a') + block)
 
-    stage_identifier = str(stage + 2)
+    stage_char = str(stage + 2)
 
     def f(x):
-        y = keras.layers.Conv3D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch2a".format(stage_identifier, block_identifier), **parameters)(x)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2a".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv3D(filters, (1, 1), strides=stride, padding="same", name="res{}{}_branch2a".format(stage_char, block_char), **parameters)(x)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2a".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2a_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv3D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2b".format(stage_identifier, block_identifier))(y)
-        y = keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv3D(filters, kernel_size, padding="same", name="res{}{}_branch2b".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2b".format(stage_char, block_char))(y)
+        y = keras.layers.Activation("relu", name="res{}{}_branch2b_relu".format(stage_char, block_char))(y)
 
-        y = keras.layers.Conv3D(filters * 4, (1, 1), padding="same", name="res{}{}_branch2c".format(stage_identifier, block_identifier), **parameters)(y)
-        y = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch2c".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Conv3D(filters * 4, (1, 1), padding="same", name="res{}{}_branch2c".format(stage_char, block_char), **parameters)(y)
+        y = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch2c".format(stage_char, block_char))(y)
 
         if block == 0:
-            shortcut = keras.layers.Conv3D(filters * 4, (1, 1), strides=stride, name="res{}{}_branch1".format(stage_identifier, block_identifier), **parameters)(x)
-            shortcut = keras.layers.BatchNormalization(axis=axis, name="bn{}{}_branch1".format(stage_identifier, block_identifier))(shortcut)
+            shortcut = keras.layers.Conv3D(filters * 4, (1, 1), strides=stride, name="res{}{}_branch1".format(stage_char, block_char), **parameters)(x)
+            shortcut = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn{}{}_branch1".format(stage_char, block_char))(shortcut)
         else:
             shortcut = x
 
-        y = keras.layers.Add(name="res{}{}".format(stage_identifier, block_identifier))([y, shortcut])
-        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_identifier, block_identifier))(y)
+        y = keras.layers.Add(name="res{}{}".format(stage_char, block_char))([y, shortcut])
+        y = keras.layers.Activation("relu", name="res{}{}_relu".format(stage_char, block_char))(y)
 
         return y
 

--- a/keras_resnet/layers/__init__.py
+++ b/keras_resnet/layers/__init__.py
@@ -1,0 +1,1 @@
+from ._batch_normalization import BatchNormalization

--- a/keras_resnet/layers/_batch_normalization.py
+++ b/keras_resnet/layers/_batch_normalization.py
@@ -1,0 +1,20 @@
+import keras
+
+class BatchNormalization(keras.layers.BatchNormalization):
+    """
+    Identical to keras.layers.BatchNormalization, but adds the option to freeze parameters.
+    """
+    def __init__(self, freeze, *args, **kwargs):
+        self.freeze = freeze
+        super(BatchNormalization, self).__init__(*args, **kwargs)
+
+        # set to non-trainable if freeze is true
+        self.trainable = not self.freeze
+
+    def call(self, *args, **kwargs):
+        # return super.call, but set training
+        return super(BatchNormalization, self).call(training=(not self.freeze), *args, **kwargs)
+
+    def get_config(self):
+        return {'freeze': self.freeze}
+

--- a/keras_resnet/models/_2d.py
+++ b/keras_resnet/models/_2d.py
@@ -13,9 +13,10 @@ import keras.models
 import keras.regularizers
 
 import keras_resnet.blocks
+import keras_resnet.layers
 
 
-def ResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwargs):
+def ResNet(inputs, blocks, block, include_top=True, classes=1000, freeze_bn=True, *args, **kwargs):
     """
     Constructs a `keras.models.Model` object using the given block count.
 
@@ -28,6 +29,8 @@ def ResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwarg
     :param include_top: if true, includes classification layers
 
     :param classes: number of classes to classify (include_top must be true)
+
+    :param freeze_bn: if true, freezes BatchNormalization layers (ie. no updates are done in these layers)
 
     :return model: ResNet model with encoding output (if `include_top=False`) or classification output (if `include_top=True`)
 
@@ -54,7 +57,7 @@ def ResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwarg
         axis = 1
 
     x = keras.layers.Conv2D(64, (7, 7), strides=(2, 2), padding="same", name="conv1")(inputs)
-    x = keras.layers.BatchNormalization(axis=axis, name="bn_conv1")(x)
+    x = keras_resnet.layers.BatchNormalization(axis=axis, freeze=freeze_bn, name="bn_conv1")(x)
     x = keras.layers.Activation("relu", name="conv1_relu")(x)
     x = keras.layers.MaxPooling2D((3, 3), strides=(2, 2), padding="same", name="pool1")(x)
 
@@ -64,7 +67,7 @@ def ResNet(inputs, blocks, block, include_top=True, classes=1000, *args, **kwarg
 
     for stage_id, iterations in enumerate(blocks):
         for block_id in range(iterations):
-            x = block(features, stage_id, block_id, numerical_name=(blocks[stage_id] > 6))(x)
+            x = block(features, stage_id, block_id, numerical_name=(blocks[stage_id] > 6), freeze_bn=freeze_bn)(x)
 
         features *= 2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
+# ignore:
+# E501 line too long (98 > 79 characters)
+[tool:pytest]
+pep8ignore = E501
+
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
This PR adds the ability to freeze BatchNorm layers, which is often done when finetuning algorithms (such as Faster RCNN). The freezing is implemented in a custom BatchNorm layer which calls Keras' BatchNorm function, while setting the two different `training` and `trainable` flags. The reason for a custom layer is because the alternative would look something like this:

```
    layer = keras.layers.BatchNormalization()
    layer.trainable = not freeze_bn
    output = layer(input, training=(not freeze_bn))
```

The custom layer changes this to:

```
output = keras_resnet.layers.BatchNormalization(freeze=freeze_bn)(input)
```

which saves lines and complexity.