### PR TITLE
Fix setting of BatchNormalization config.

### DIFF
--- a/keras_resnet/layers/_batch_normalization.py
+++ b/keras_resnet/layers/_batch_normalization.py
@@ -17,4 +17,6 @@ class BatchNormalization(keras.layers.BatchNormalization):
         return super(BatchNormalization, self).call(training=(not self.freeze), *args, **kwargs)
 
     def get_config(self):
-        return {'freeze': self.freeze}
+        config = super(BatchNormalization, self).get_config()
+        config.update({'freeze': self.freeze})
+        return config


### PR DESCRIPTION
The configuration of the batch normalization layers wasn't stored correctly, because the super class was not called. This causes parameters like `name` or `epsilon` to be lost when loading a previously saved model.