### PR TITLE
fixed an error in example code in README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ A tantalizing preview of Keras-ResNet simplicity:
 
     >>> x = keras.layers.Input(shape)
 
-    >>> model = keras_resnet.classifiers.ResNet50(x, classes=classes)
+    >>> model = keras_resnet.models.ResNet50(x, classes=classes)
 
     >>> model.compile("adam", "categorical_crossentropy", ["accuracy"])
 


### PR DESCRIPTION
Hi Allen and Claire,
There is an error when running the example code provided in the README file.
keras_resnet.classifiers does not exist, I replaced it by keras_resnet.models
Holger
