### PR TITLE
Fix behaviour of unfrozen BatchNormalization layer (resolves #46)

### DIFF
--- a/keras_resnet/layers/_batch_normalization.py
+++ b/keras_resnet/layers/_batch_normalization.py
@@ -13,8 +13,10 @@ class BatchNormalization(keras.layers.BatchNormalization):
         self.trainable = not self.freeze
 
     def call(self, *args, **kwargs):
-        # return super.call, but set training
-        return super(BatchNormalization, self).call(training=(not self.freeze), *args, **kwargs)
+        # Force test mode if frozen, otherwise use default behaviour (i.e., training=None).
+        if self.freeze:
+            kwargs['training'] = False
+        return super(BatchNormalization, self).call(*args, **kwargs)
 
     def get_config(self):
         config = super(BatchNormalization, self).get_config()


### PR DESCRIPTION
Previously, if `BatchNormalization` was initialized with `BatchNormalization(freeze=False)`, its behaviour was not equivalent to the standard `BatchNormalization` layer, as one would expect. Instead, it was always forced to be in training mode, providing wrong validation results.

This PR does not change the behaviour for `freeze=True`, but makes the layer equivalent to the standard `BatchNormalization` layer from Keras for `freeze=False`.