### PR TITLE
Click.option-s should have help text

### DIFF
--- a/keras_resnet/benchmarks/__init__.py
+++ b/keras_resnet/benchmarks/__init__.py
@@ -41,7 +41,7 @@ _names = {
         ]
     )
 )
-@click.option("--device", default=0)
+@click.option("--device", default=0, type=int, help='Comma separator list of devices for gpu_options.visible_device_list, e.g. 1,2,3.')
 @click.option(
     "--name",
     default="ResNet-50",


### PR DESCRIPTION
## What?
Add `help` text to click.option

## Why?
Click.option should ideally have a `help` text defined to be useful.
